### PR TITLE
Support Open Babel >3 in python interface

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -2,4 +2,4 @@ from RASPA2.raspa2 import *
 from RASPA2.output_parser import parse
 
 __author__ = "David Dubbeldam"
-__version__ = "2.0.2"
+__version__ = "2.0.4"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ for structure_type in structure_types:
 
 setup(
     name="RASPA2",
-    version="2.0.3",
+    version="2.0.4",
     description="A general purpose classical simulation package.",
     url="http://github.com/numat/RASPA2/",
     author="David Dubbeldam",


### PR DESCRIPTION
@dubbelda hope you've been well!

This PR is to handle Open Babel 3's new API while still supporting Open Babel 2. Small scope, pretty straightforward.

More generally, it'd be curious to get your thoughts on what (if any) value this python wrapper's provided over the last few years. If there's a use case to integrate it more deeply into RASPA, I'm open. Alternately, if it's a largely useless appendage, I'm okay removing it and maybe putting it into a separate repo w/ RASPA as a dependency. Let me know - happy to help either way!
