### PR TITLE
Set BoundaryCondition to CUBIC when possible

### DIFF
--- a/src/framework.c
+++ b/src/framework.c
@@ -275,6 +275,24 @@ void RemoveQuotesAroundString(char *string)
   }
 }
 
+void SetBoundaryCondition(int system, REAL eps_angle, REAL eps_length, REAL alpha, REAL beta, REAL gamma, REAL A, REAL B, REAL C)
+{
+  if((fabs(alpha-90.0)>eps_angle)||(fabs(beta-90.0)>eps_angle)||(fabs(gamma-90.0)>eps_angle))
+    BoundaryCondition[system]=TRICLINIC;
+  else if((fabs(A-B)>eps_length)||(fabs(A-C)>eps_length)||(fabs(B-C)>eps_length))
+    BoundaryCondition[system]=RECTANGULAR;
+  else
+    BoundaryCondition[system]=CUBIC;
+}
+
+void SetBoundaryConditionFromSystem(int system, REAL eps_angle, REAL eps_length)
+{
+  SetBoundaryCondition(system, eps_angle, eps_length,
+                       AlphaAngle[system]*RAD2DEG, BetaAngle[system]*RAD2DEG, GammaAngle[system]*RAD2DEG,
+                       BoxProperties[system].ax, BoxProperties[system].ay, BoxProperties[system].az
+  );
+}
+
 
 /*********************************************************************************************************
  * Name       | ReadFrameworkDefinitionCIF                                                               *
@@ -1992,14 +2010,7 @@ void ReadFrameworkDefinitionCIF(void)
   // determine boundary conditions from angles
   if(BoundaryCondition[CurrentSystem]==UNINITIALIZED_BOUNDARY_CONDITION)
   {
-    if((fabs(alpha-90.0)>0.001)||(fabs(beta-90.0)>0.001)||(fabs(gamma-90.0)>0.001))
-      BoundaryCondition[CurrentSystem]=TRICLINIC;
-    else
-    {
-      if((fabs(A-B)>0.00001)||(fabs(A-C)>0.00001)||(fabs(B-C)>0.00001))
-        BoundaryCondition[CurrentSystem]=RECTANGULAR;
-      else BoundaryCondition[CurrentSystem]=TRICLINIC;
-    }
+    SetBoundaryCondition(CurrentSystem, 0.001, 0.00001, alpha, beta, gamma, A, B, C);
   }
   AlphaAngle[CurrentSystem]=alpha*DEG2RAD;
   BetaAngle[CurrentSystem]=beta*DEG2RAD;
@@ -3015,17 +3026,7 @@ void ReadFrameworkDefinitionMOL(void)
 
   if(BoundaryCondition[CurrentSystem]==UNINITIALIZED_BOUNDARY_CONDITION)
   {
-    // determine boundary conditions from angles
-    if((fabs(AlphaAngle[CurrentSystem]-90.0)>0.01)||
-       (fabs(BetaAngle[CurrentSystem]-90.0)>0.01)||
-       (fabs(GammaAngle[CurrentSystem]-90.0)>0.01))
-      BoundaryCondition[CurrentSystem]=TRICLINIC;
-    else
-    {
-      if((fabs(A-B)>0.01)||(fabs(A-C)>0.01)||(fabs(B-C)>0.01))
-        BoundaryCondition[CurrentSystem]=RECTANGULAR;
-      else BoundaryCondition[CurrentSystem]=RECTANGULAR;
-    }
+    SetBoundaryCondition(CurrentSystem, 0.01, 0.01, AlphaAngle[CurrentSystem], BetaAngle[CurrentSystem], GammaAngle[CurrentSystem], A, B, C);
   }
   AlphaAngle[CurrentSystem]*=M_PI/180.0;
   BetaAngle[CurrentSystem]*=M_PI/180.0;
@@ -3310,14 +3311,7 @@ void ReadFrameworkDefinitionDLPOLY(void)
   BetaAngle[CurrentSystem]=acos(BoxProperties[CurrentSystem].by);
   GammaAngle[CurrentSystem]=acos(BoxProperties[CurrentSystem].bz);
 
-  // determine boundary conditions from angles
-  if((fabs(AlphaAngle[CurrentSystem]-90.0*DEG2RAD)>0.001)||
-     (fabs(BetaAngle[CurrentSystem]-90.0*DEG2RAD)>0.001)||
-     (fabs(GammaAngle[CurrentSystem]-90.0*DEG2RAD)>0.001))
-    BoundaryCondition[CurrentSystem]=TRICLINIC;
-  else BoundaryCondition[CurrentSystem]=RECTANGULAR;
-
-  BoundaryCondition[CurrentSystem]=TRICLINIC;
+  SetBoundaryConditionFromSystem(CurrentSystem, 0.001, 0.00001);
 
   Framework[CurrentSystem].NumberOfAsymmetricAtoms[CurrentFramework]=int_temp3;
   Framework[CurrentSystem].AtomsAsymmetric[CurrentFramework]=(FRAMEWORK_ASYMMETRIC_ATOM*)calloc(int_temp3,sizeof(FRAMEWORK_ASYMMETRIC_ATOM));
@@ -3431,15 +3425,7 @@ void ReadFrameworkDefinitionCSSR(void)
 
   if(BoundaryCondition[CurrentSystem]==UNINITIALIZED_BOUNDARY_CONDITION)
   {
-    // determine boundary conditions from angles
-    if((fabs(AlphaAngle[CurrentSystem]-90.0)>0.001)||(fabs(BetaAngle[CurrentSystem]-90.0)>0.001)||(fabs(GammaAngle[CurrentSystem]-90.0)>0.001))
-      BoundaryCondition[CurrentSystem]=TRICLINIC;
-    else
-    {
-      if((fabs(A-B)>0.00001)||(fabs(A-C)>0.00001)||(fabs(B-C)>0.00001))
-        BoundaryCondition[CurrentSystem]=RECTANGULAR;
-      else BoundaryCondition[CurrentSystem]=TRICLINIC;
-    }
+    SetBoundaryCondition(CurrentSystem, 0.001, 0.00001, AlphaAngle[CurrentSystem], BetaAngle[CurrentSystem], GammaAngle[CurrentSystem], A, B, C);
   }
   AlphaAngle[CurrentSystem]*=M_PI/180.0;
   BetaAngle[CurrentSystem]*=M_PI/180.0;

--- a/src/framework.h
+++ b/src/framework.h
@@ -128,6 +128,9 @@ extern int (*ForbiddenConnectivityTypes)[3];
 
 void CheckFrameworkCharges(void);
 void AddAsymmetricAtom(FRAMEWORK_ASYMMETRIC_ATOM atom);
+void SetBoundaryCondition(int system, REAL eps_angle, REAL eps_length, REAL alpha, REAL beta, REAL gamma, REAL A, REAL B, REAL C);
+void SetBoundaryConditionFromSystem(int system, REAL eps_angle, REAL eps_length);
+
 void ReadFrameworkDefinitionCSSR(void);
 void ReadFrameworkDefinitionDLPOLY(void);
 void CreateAsymetricFrameworkAtoms(void);

--- a/src/grids.c
+++ b/src/grids.c
@@ -585,6 +585,20 @@ void MakeGrid(void)
     }
     fprintf(stderr, "Writing Grid\n");
     WriteVDWGrid(GridTypeList[l]);
+
+    for(i=0;i<=NumberOfVDWGridPoints.x;i++)
+    {
+      for(j=0;j<=NumberOfVDWGridPoints.y;j++)
+      {
+        for(k=0;k<=NumberOfVDWGridPoints.z;k++)
+        {
+          free(VDWGrid[GridTypeList[l]][i][j][k]);
+        }
+        free(VDWGrid[GridTypeList[l]][i][j]);
+      }
+      free(VDWGrid[GridTypeList[l]][i]);
+    }
+    free(VDWGrid[GridTypeList[l]]);
   }
 
   // compute the number of grid points
@@ -740,7 +754,6 @@ int WriteVDWGrid(int l)
       for(j=0;j<=NumberOfVDWGridPoints.y;j++)
         for(k=0;k<=NumberOfVDWGridPoints.z;k++)
           fwrite(&VDWGrid[l][i][j][k][m],1,sizeof(float),FilePtr);
-
 
   fclose(FilePtr);
   return 0;

--- a/src/grids.c
+++ b/src/grids.c
@@ -245,6 +245,7 @@ VECTOR MapToUnitCell(VECTOR pos)
 
   switch(BoundaryCondition[CurrentSystem])
   {
+    case CUBIC:
     case RECTANGULAR:
       pos.x-=UnitCellSize[CurrentSystem].x*(REAL)(NINT(pos.x/UnitCellSize[CurrentSystem].x));
       pos.y-=UnitCellSize[CurrentSystem].y*(REAL)(NINT(pos.y/UnitCellSize[CurrentSystem].y));
@@ -399,6 +400,7 @@ void MakeASCIGrid(void)
         {
           switch(BoundaryCondition[CurrentSystem])
           {
+            case CUBIC:
             case RECTANGULAR:
             case TRICLINIC:
             default:
@@ -537,6 +539,7 @@ void MakeGrid(void)
         {
           switch(BoundaryCondition[CurrentSystem])
           {
+            case CUBIC:
             case RECTANGULAR:
             case TRICLINIC:
             default:
@@ -643,6 +646,7 @@ void MakeGrid(void)
       {
         switch(BoundaryCondition[CurrentSystem])
         {
+          case CUBIC:
           case RECTANGULAR:
           case TRICLINIC:
           default:
@@ -992,6 +996,7 @@ REAL InterpolateVDWGrid(int typeA,VECTOR pos)
 
   switch(BoundaryCondition[CurrentSystem])
   {
+    case CUBIC:
     case RECTANGULAR:
       // the position has to be moved back to the main unit cell using the rectangular boundary condition
       pos.x-=UnitCellSize[CurrentSystem].x*(REAL)(NINT(pos.x/UnitCellSize[CurrentSystem].x));
@@ -1092,6 +1097,7 @@ REAL InterpolateVDWForceGrid(int typeA,VECTOR pos,VECTOR *Force)
 
   switch(BoundaryCondition[CurrentSystem])
   {
+    case CUBIC:
     case RECTANGULAR:
       // the position has to be moved back to the main unit cell using the rectangular boundary condition
       pos.x-=UnitCellSize[CurrentSystem].x*(REAL)(NINT(pos.x/UnitCellSize[CurrentSystem].x));
@@ -1213,6 +1219,7 @@ REAL InterpolateCoulombGrid(int typeA,VECTOR pos)
 
   switch(BoundaryCondition[CurrentSystem])
   {
+    case CUBIC:
     case RECTANGULAR:
       // the position has to be moved back to the main unit cell using the rectangular boundary condition
       pos.x-=UnitCellSize[CurrentSystem].x*(REAL)(NINT(pos.x/UnitCellSize[CurrentSystem].x));
@@ -1310,6 +1317,7 @@ REAL InterpolateCoulombForceGrid(int typeA,VECTOR pos,VECTOR *Force)
 
   switch(BoundaryCondition[CurrentSystem])
   {
+    case CUBIC:
     case RECTANGULAR:
       // the position has to be moved back to the main unit cell using the rectangular boundary condition
       pos.x-=UnitCellSize[CurrentSystem].x*(REAL)(NINT(pos.x/UnitCellSize[CurrentSystem].x));
@@ -1474,6 +1482,7 @@ void TestForceGrid(FILE *FilePtr)
       {
         switch(BoundaryCondition[CurrentSystem])
         {
+          case CUBIC:
           case RECTANGULAR:
             pos.x=Box[CurrentSystem].ax*RandomNumber();
             pos.y=Box[CurrentSystem].by*RandomNumber();
@@ -1669,6 +1678,7 @@ INT_VECTOR3 ConvertXYZPositionToGridIndex(VECTOR pos)
 
   switch(BoundaryCondition[CurrentSystem])
   {
+    case CUBIC:
     case RECTANGULAR:
       // the position has to be moved back to the main unit cell using the rectangular boundary condition
       pos.x-=UnitCellSize[CurrentSystem].x*(REAL)(NINT(pos.x/UnitCellSize[CurrentSystem].x));

--- a/src/input.c
+++ b/src/input.c
@@ -2696,8 +2696,9 @@ int ReadInput(char *input)
     if(strcasecmp("BoundaryCondition",keyword)==0)
     {
       if(strcasecmp("None",firstargument)==0) BoundaryCondition[CurrentSystem]=FINITE;
-      if(strcasecmp("Reactangular",firstargument)==0) BoundaryCondition[CurrentSystem]=RECTANGULAR;
+      if(strcasecmp("Rectangular",firstargument)==0) BoundaryCondition[CurrentSystem]=RECTANGULAR;
       if(strcasecmp("Triclinic",firstargument)==0) BoundaryCondition[CurrentSystem]=TRICLINIC;
+      if(strcasecmp("Cubic",firstargument)==0) BoundaryCondition[CurrentSystem]=CUBIC;
     }
     if(strcasecmp("GibbsVolumeChangeProbability",keyword)==0) sscanf(arguments,"%lf",&ProbabilityGibbsVolumeChangeMove);
     if(strcasecmp("MaximumGibbsVolumeChange",keyword)==0)
@@ -6677,9 +6678,7 @@ int ReadInput(char *input)
     // determine boundary conditions from angles
     if(BoundaryCondition[i]==UNINITIALIZED_BOUNDARY_CONDITION)
     {
-      if((fabs(AlphaAngle[i]*RAD2DEG-90.0)>0.001)||(fabs(BetaAngle[i]*RAD2DEG-90.0)>0.001)||(fabs(GammaAngle[i]*RAD2DEG-90.0)>0.001))
-        BoundaryCondition[i]=TRICLINIC;
-      else BoundaryCondition[i]=RECTANGULAR;
+      SetBoundaryConditionFromSystem(i, 0.001, 0.00001);
     }
   }
 
@@ -9640,11 +9639,7 @@ void ReadRestartFile(void)
     // determine boundary conditions from angles
     if((BoundaryCondition[CurrentSystem]!=UNINITIALIZED_BOUNDARY_CONDITION)&&(BoundaryCondition[CurrentSystem]!=FINITE))
     {
-      if((fabs(AlphaAngle[CurrentSystem]*RAD2DEG-90.0)>0.001)||
-         (fabs(BetaAngle[CurrentSystem]*RAD2DEG-90.0)>0.001)||
-         (fabs(GammaAngle[CurrentSystem]*RAD2DEG-90.0)>0.001))
-        BoundaryCondition[CurrentSystem]=TRICLINIC;
-      else BoundaryCondition[CurrentSystem]=RECTANGULAR;
+      SetBoundaryConditionFromSystem(CurrentSystem, 0.001, 0.00001);
     }
 
     if(Framework[CurrentSystem].FrameworkModel==NONE)
@@ -9785,11 +9780,7 @@ void ReadRestartFileOld(void)
         // determine boundary conditions from angles
         if((BoundaryCondition[CurrentSystem]!=UNINITIALIZED_BOUNDARY_CONDITION)&&(BoundaryCondition[CurrentSystem]!=FINITE))
         {
-          if((fabs(AlphaAngle[CurrentSystem]-90.0)>0.001)||
-             (fabs(BetaAngle[CurrentSystem]-90.0)>0.001)||
-             (fabs(GammaAngle[CurrentSystem]-90.0)>0.001))
-            BoundaryCondition[CurrentSystem]=TRICLINIC;
-          else BoundaryCondition[CurrentSystem]=RECTANGULAR;
+          SetBoundaryConditionFromSystem(CurrentSystem, 0.001, 0.00001);
         }
 
         if(Framework[CurrentSystem].FrameworkModel==NONE)

--- a/src/mc_moves.c
+++ b/src/mc_moves.c
@@ -10263,6 +10263,11 @@ int ParallelTemperingMove(void)
 
   cpu_before=get_cpu_time();
 
+  if (NumberOfSystems == 1) {
+    fprintf(stderr, "ERROR: cannot do parallel tempering on a single system");
+    exit(0);
+  }
+
   SystemA=(int)(((REAL)NumberOfSystems-(REAL)1.0)*RandomNumber());
   SystemB=SystemA+1;
 

--- a/src/molecule.c
+++ b/src/molecule.c
@@ -5266,6 +5266,7 @@ VECTOR MapToBox(VECTOR pos)
 
   switch(BoundaryCondition[CurrentSystem])
   {
+    case CUBIC:
     case RECTANGULAR:
       pos.x-=Box[CurrentSystem].ax*NINT(pos.x/Box[CurrentSystem].ax);
       pos.y-=Box[CurrentSystem].by*NINT(pos.y/Box[CurrentSystem].by);

--- a/src/potentials.c
+++ b/src/potentials.c
@@ -10959,8 +10959,8 @@ void PotentialSecondDerivative(int typeA,int typeB,REAL rr,REAL *energy,REAL *fa
 void PotentialThirdDerivative(int typeA,int typeB,REAL rr,REAL *energy,REAL *factor1,REAL *factor2,REAL *factor3)
 {
   REAL fcVal1,fcVal2,fcVal3,U,rri3;
-  REAL arg1,arg2,arg3,arg4;
-  REAL r;
+  REAL arg1,arg2,arg3,arg4,arg5;
+  REAL r,r6,exp_term;
 
   switch(PotentialType[typeA][typeB])
   {
@@ -11011,6 +11011,53 @@ void PotentialThirdDerivative(int typeA,int typeB,REAL rr,REAL *energy,REAL *fac
       fcVal2=arg1*arg2*exp(-arg2*r/arg3)*(exp(arg2*(0.5+0.5*r/arg3))*(-arg3-0.5*arg2*r)+exp(arg2)*(arg3+arg2*r))/(rr*r*SQR(arg3));
       fcVal3=(arg2*arg1*exp((arg2*(arg3 - r))/arg3)*((12*SQR(arg3))/exp((arg2*(arg3 - r))/(2*arg3)) - 12*SQR(arg3) - 4*SQR(arg2)*rr - 12*arg2*arg3*r + (SQR(arg2)*rr)/exp((arg2*(arg3 - r))/(2*arg3)) + (6*arg2*arg3*r)/exp((arg2*(arg3 - r))/(2*arg3))))/(4*CUBE(arg3)*SQR(rr)*r);
       break;
+
+    case BUCKINGHAM:
+      // p_0*exp(-p_1*r)-p_2/r^6
+      // ======================================================================================
+      // p_0/k_B [K]
+      // p_1     [A^-1]
+      // p_2/k_B [K A^6]
+      // p_3/k_B [K]  (non-zero for a shifted potential)
+      arg1=PotentialParms[typeA][typeB][0];
+      arg2=PotentialParms[typeA][typeB][1];
+      arg3=PotentialParms[typeA][typeB][2];
+      arg4=PotentialParms[typeA][typeB][3];
+      r=sqrt(rr);
+      r6=CUBE(rr);
+      rri3=arg3*CUBE(1.0/rr);
+      exp_term=arg1*exp(-arg2*r);
+      U=-rri3+exp_term-arg4;
+      fcVal1=-arg2*exp_term/r+(6.0/rr)*rri3;
+      fcVal2=-48.0*rri3/(rr*rr)+arg2*exp_term*(1.0+arg2*r)/(rr*r);
+      fcVal3=-(3*arg1*SQR(arg2)*r6*rr - 480*arg3*exp(arg2*r) + arg1*CUBE(arg2)*r6*rr*r + 3*arg1*arg2*r6*r)/(SQR(r6)*exp(arg2*r));
+      break;
+
+    case BUCKINGHAM2:
+      // if(r<p_3) 1e10 else p_0*exp(-p_1*r)-p_2/r^6
+      // ======================================================================================
+      // p_0/k_B [K]
+      // p_1     [A^-1]
+      // p_2/k_B [K A^6]
+      // p_3     [A]
+      // p_4/k_B [K]  (non-zero for a shifted potential)
+      // Note: the case r<p_3 can not occur here as it is supposed to be avoided by the high energy in 'PotentialValue'
+      //       in Molecular Dynamics the usual Buckingham should suffice
+      arg1=PotentialParms[typeA][typeB][0];
+      arg2=PotentialParms[typeA][typeB][1];
+      arg3=PotentialParms[typeA][typeB][2];
+      arg4=PotentialParms[typeA][typeB][3];
+      arg5=PotentialParms[typeA][typeB][4];
+      r=sqrt(rr);
+      r6=CUBE(rr);
+      rri3=arg3*CUBE(1.0/rr);
+      exp_term=arg1*exp(-arg2*r);
+      U=-rri3+exp_term-arg5;
+      fcVal1=-arg2*exp_term/r+(6.0/rr)*rri3;
+      fcVal2=-48.0*rri3/(rr*rr)+arg2*exp_term*(1.0+arg2*r)/(rr*r);
+      fcVal3=-(3*arg1*SQR(arg2)*r6*rr - 480*arg3*exp(arg2*r) + arg1*CUBE(arg2)*r6*rr*r + 3*arg1*arg2*r6*r)/(SQR(r6)*exp(arg2*r));
+      break;
+
     default:
       U=0.0;
       fcVal1=0.0;

--- a/src/simulation.c
+++ b/src/simulation.c
@@ -745,7 +745,7 @@ void InitializeReplicaBox(void)
 
   // use cell lists for sufficiently large systems
   if((NumberOfCellListCells[CurrentSystem].x>3)&&(NumberOfCellListCells[CurrentSystem].y>3)&&
-     (NumberOfCellListCells[CurrentSystem].z>3)&&(BoundaryCondition[CurrentSystem]==RECTANGULAR))
+     (NumberOfCellListCells[CurrentSystem].z>3)&&((BoundaryCondition[CurrentSystem]==RECTANGULAR)||(BoundaryCondition[CurrentSystem]==CUBIC)))
 //  if((NumberOfCellListCells[CurrentSystem].x>3)&&(NumberOfCellListCells[CurrentSystem].y>3)&&
 //     (NumberOfCellListCells[CurrentSystem].z>3))
     UseCellLists[CurrentSystem]=TRUE;


### PR DESCRIPTION
Hi! I noticed that doing a simple MC simulation of faujasite resulted in this curious note in the output:
```
System Properties
===========================================================================
Unit cell size: 24.257600 24.257600 24.257600
Cell angles (radians)  alpha: 1.570796 beta: 1.570796 gamma: 1.570796
Cell angles (degrees)  alpha: 90.000000 beta: 90.000000 gamma: 90.000000
Number of unitcells [a]: 1
Number of unitcells [b]: 1
Number of unitcells [c]: 1

TRICLINIC Boundary conditions: alpha!=90 or beta!=90 or gamma!=90
```
so I investigated and it turns out that, in framework.c, lines 2001 and 3441 wrongly set the `BoundaryCondition` to `TRICLINIC` instead of `CUBIC` (and lines 3320 always overwrites the preceding lines into `TRICLINIC` as well).

This PR fixes that and also adds `CUBIC` as an option whenever only `RECTANGULAR` and `TRICLINIC` exist (by defaulting to `RECTANGULAR`). I believe there is actually no difference between `CUBIC` and `RECTANGULAR` in the current code, but at least this code allows specializing on `CUBIC` in future developments.